### PR TITLE
Refactor/use bind instead of extra arrows

### DIFF
--- a/dist/Index.d.ts
+++ b/dist/Index.d.ts
@@ -40,6 +40,6 @@ export declare const validateToken: (host: string, token: string) => Promise<boo
  * @throws {CannotConnect}
  */
 export declare const connectToJwt: (host: string) => Promise<{
-    generateToken: (username: string, password: string) => Promise<JWT>;
-    validateToken: (token: string) => Promise<boolean>;
+    generateToken: any;
+    validateToken: any;
 }>;

--- a/dist/Index.js
+++ b/dist/Index.js
@@ -103,7 +103,6 @@ exports.connectToJwt = function (host) { return __awaiter(_this, void 0, void 0,
                 return [2 /*return*/, {
                         /**
                          * Authenticate user
-                         * @param host - host URL
                          * @param username - user's name used to login
                          * @param password - user's password used to login
                          * @throws {CannotAuthenticate}

--- a/dist/Index.js
+++ b/dist/Index.js
@@ -107,13 +107,13 @@ exports.connectToJwt = function (host) { return __awaiter(_this, void 0, void 0,
                          * @param password - user's password used to login
                          * @throws {CannotAuthenticate}
                          */
-                        generateToken: function (username, password) { return exports.generateToken(host, username, password); },
+                        generateToken: exports.generateToken.bind(null, host),
                         /**
                          * Validate token
                          * @param token - token to validate
                          * @returns true if token is successfully validated
                          */
-                        validateToken: function (token) { return exports.validateToken(host, token); },
+                        validateToken: exports.validateToken.bind(null, host),
                     }];
         }
     });

--- a/lib/Index.ts
+++ b/lib/Index.ts
@@ -75,7 +75,6 @@ export const connectToJwt = async (host: string) => {
     return {
         /**
          * Authenticate user
-         * @param host - host URL
          * @param username - user's name used to login
          * @param password - user's password used to login
          * @throws {CannotAuthenticate}

--- a/lib/Index.ts
+++ b/lib/Index.ts
@@ -79,13 +79,13 @@ export const connectToJwt = async (host: string) => {
          * @param password - user's password used to login
          * @throws {CannotAuthenticate}
          */
-        generateToken: (username: string, password: string) => generateToken(host, username, password),
+        generateToken: generateToken.bind(null, host),
 
         /**
          * Validate token
          * @param token - token to validate
          * @returns true if token is successfully validated
          */
-        validateToken: (token: string) => validateToken(host, token),
+        validateToken: validateToken.bind(null, host),
     };
 };


### PR DESCRIPTION
I took the liberty to use `Function.prototype.bind` for the API `connectToJwt` returns. This doesn't bring any improvement over the existing code. The main benefit of this is that we let the JavaScript VM handle the creation of those functions and perform argument binding itself.

Adrian.